### PR TITLE
Remove unmatched uv_unref() causing segfault

### DIFF
--- a/src/node-midi.cpp
+++ b/src/node-midi.cpp
@@ -234,7 +234,6 @@ public:
         NodeMidiInput* input = new NodeMidiInput();
         input->message_async.data = input;
         uv_async_init(uv_default_loop(), &input->message_async, NodeMidiInput::EmitMessage);
-        uv_unref((uv_handle_t*)uv_default_loop());
         input->Wrap(args.This());
         return args.This();
     }
@@ -300,6 +299,7 @@ public:
         NodeMidiInput* input = ObjectWrap::Unwrap<NodeMidiInput>(args.This());
         input->Unref();
         input->in->closePort();
+        uv_close((uv_handle_t*)&input->message_async, NULL);
         return scope.Close(v8::Undefined());
     }
 


### PR DESCRIPTION
Fixes https://github.com/justinlatimer/node-midi/issues/16

~~The tests seem to hang but I'm not sure if that's normal:~~ Tests now run correctly

```
amorton@pavlov:~/projects/node-midi% npm test

> midi@0.7.0 test /Users/amorton/projects/node-midi
> node test/virtual-loopback-test-automated.js

Enumerating inputs
Input found: MidiKeys
Input found: node-midi Virtual Output
Opening node-midi Virtual Output
Enumerating outputs
Output found: MidiKeys
Opening node-midi Virtual Input
Sending message
Virtual input recieved m:144,23,81 d:0
Input recieved m:144,33,81 d:0
Sending message
Virtual input recieved m:144,23,81 d:1.000385828
Input recieved m:144,33,81 d:0.999496216
Sending message
Virtual input recieved m:144,23,81 d:1.0010956880000002
Input recieved m:144,33,81 d:1.0011307120000001
Sending message
Virtual input recieved m:144,23,81 d:1.001120228
Input recieved m:144,33,81 d:1.000997857
Sending message
Virtual input recieved m:144,23,81 d:1.001917765
Input recieved m:144,33,81 d:1.002010969
Sending message
Virtual input recieved m:144,23,81 d:1.000205188
Input recieved m:144,33,81 d:1.0002009040000002
Sending message
Virtual input recieved m:144,23,81 d:1.00220642
Input recieved m:144,33,81 d:1.002208001
Sending message
Virtual input recieved m:144,23,81 d:1.002072784
Input recieved m:144,33,81 d:1.00208373
Sending message
Virtual input recieved m:144,23,81 d:1.0011529670000001
Input recieved m:144,33,81 d:1.0012620220000001
amorton@pavlov:~/projects/node-midi% 
```

I'll try building it on 0.8.x and see what the tests do there.
