### PR TITLE
Added missing MIDI Clock event case.

### DIFF
--- a/src/lib/RtMidi/RtMidi.cpp
+++ b/src/lib/RtMidi/RtMidi.cpp
@@ -1210,6 +1210,10 @@ extern "C" void *alsaMidiHandler( void *ptr )
       if ( !( data->ignoreFlags & 0x02 ) ) doDecode = true;
       break;
 
+    case SND_SEQ_EVENT_CLOCK: // MIDI timing clock
+      if ( !( data->ignoreFlags & 0x02 ) ) doDecode = true;
+      break;
+
     case SND_SEQ_EVENT_SENSING: // Active sensing
       if ( !( data->ignoreFlags & 0x04 ) ) doDecode = true;
       break;


### PR DESCRIPTION
And here comes the pending fix. I added the missing MIDI Clock Event case into RtMidi. This finally makes RtMidi behave correctly when using the ignoreTypes() function.
