### PR TITLE
Fix compile error when running nw-gyp for nw.js v0.10.x

### DIFF
--- a/src/node-midi.cpp
+++ b/src/node-midi.cpp
@@ -245,7 +245,7 @@ public:
 
         NodeMidiInput* input = new NodeMidiInput();
         input->message_async.data = input;
-        uv_async_init(uv_default_loop(), &input->message_async, NodeMidiInput::EmitMessage);
+        uv_async_init(uv_default_loop(), &input->message_async, (uv_async_cb) NodeMidiInput::EmitMessage);
         input->Wrap(args.This());
 
         NanReturnValue(args.This());


### PR DESCRIPTION
I'm working on getting node-midi to compile for use in nw.js. I get the following compile error when I run `nw-gyp rebuild --target=0.10.5`

 "../src/node-midi.cpp:248:9: error: no matching function for call to 'uv_async_init'
        uv_async_init(uv_default_loop(), &input->message_async, NodeMidiInput::EmitMessage);
        ^~~~~~~~~~~~~"

This fixes the error by doing an explicit typecast. 