### PR TITLE
Add Travis for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: node_js
+node_js:
+  - "0.12"
+  - "0.10"
+  - "0.8"
+  - "iojs"
+  - "iojs-v1.0.4"
+before_install:
+ - sudo apt-get install libasound2-dev alsa-utils alsa-oss
+notifications:
+  email: false
+# Travis has no snd-dummy driver (https://github.com/travis-ci/travis-ci/issues/1754)
+# so our tests won't run. We run `npm install` as the test script so build errors
+# appear as test failures.
+install: true
+script: npm install


### PR DESCRIPTION
It won't run our tests but it'll test that it builds correctly. I did a build of 0.6 to check that it [fails correctly](https://travis-ci.org/drewish/node-midi/builds/51739570). Compare that to this commit [passing](https://travis-ci.org/drewish/node-midi/builds/51740108).