### PR TITLE
Let NAN handle the callback definition

### DIFF
--- a/src/node-midi.cpp
+++ b/src/node-midi.cpp
@@ -194,14 +194,10 @@ public:
         uv_mutex_destroy(&message_mutex);
     }
 
-#if NODE_VERSION_AT_LEAST(0, 11, 0)
-    static void EmitMessage(uv_async_t *w) {
-#else
-    static void EmitMessage(uv_async_t *w, int status) {
-        assert(status == 0);
-#endif
+    static NAUV_WORK_CB(EmitMessage)
+    {
         NanScope();
-        NodeMidiInput *input = static_cast<NodeMidiInput*>(w->data);
+        NodeMidiInput *input = static_cast<NodeMidiInput*>(async->data);
         uv_mutex_lock(&input->message_mutex);
         v8::Local<v8::Function> emitFunction = NanObjectWrapHandle(input)->Get(NanNew<v8::String>(symbol_emit)).As<v8::Function>();
         while (!input->message_queue.empty())


### PR DESCRIPTION
Fixes #63 Instead of having a conditional definition of `EmitMessage` based on the Node version we'll let NAN handle it based on [the libuv version](https://github.com/rvagg/nan/blob/1c811c9d4c01a03fd2cf8df631e61c47ceeb2cc6/nan.h#L95).
