### PR TITLE
API improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,11 +37,11 @@
   },
   "dependencies": {
     "bindings": "~1.2.1",
-    "nan": "~1.6.0"
+    "nan": "~1.7.0"
   },
   "devDependencies": {
-    "mocha": ">= 2.1.0",
-    "should": ">= 5.0.1"
+    "mocha": ">= 2.2.4",
+    "should": ">= 5.2.0"
   },
   "repository": {
     "type": "git",

--- a/src/lib/RtMidi/RtMidi.cpp
+++ b/src/lib/RtMidi/RtMidi.cpp
@@ -1609,7 +1609,7 @@ void MidiInAlsa :: openVirtualPort( std::string portName )
     snd_seq_port_info_set_midi_channels(pinfo, 16);
 #ifndef AVOID_TIMESTAMPING
     snd_seq_port_info_set_timestamping(pinfo, 1);
-    snd_seq_port_info_set_timestamp_real(pinfo, 1);    
+    snd_seq_port_info_set_timestamp_real(pinfo, 1);
     snd_seq_port_info_set_timestamp_queue(pinfo, data->queue_id);
 #endif
     snd_seq_port_info_set_name(pinfo, portName.c_str());
@@ -1729,6 +1729,7 @@ void MidiOutAlsa :: initialize( const std::string& clientName )
   data->seq = seq;
   data->portNum = -1;
   data->vport = -1;
+  data->subscription = 0;
   data->bufferSize = 32;
   data->coder = 0;
   data->buffer = 0;

--- a/src/lib/RtMidi/RtMidi.cpp
+++ b/src/lib/RtMidi/RtMidi.cpp
@@ -646,12 +646,6 @@ void MidiInCore :: openPort( unsigned int portNumber, const std::string portName
 
 void MidiInCore :: openVirtualPort( const std::string portName )
 {
-  if ( connected_ ) {
-    errorString_ = "MidiInCore::openVirtualPort: a valid connection already exists!";
-    error( RtMidiError::WARNING, errorString_ );
-    return;
-  }
-
   CoreMidiData *data = static_cast<CoreMidiData *> (apiData_);
 
   // Create a virtual MIDI input destination.
@@ -667,8 +661,6 @@ void MidiInCore :: openVirtualPort( const std::string portName )
 
   // Save our api-specific connection information.
   data->endpoint = endpoint;
-
-  connected_ = true;
 }
 
 void MidiInCore :: closePort( void )
@@ -967,12 +959,6 @@ void MidiOutCore :: closePort( void )
 
 void MidiOutCore :: openVirtualPort( std::string portName )
 {
-  if ( connected_ ) {
-    errorString_ = "MidiOutCore::openVirtualPort: a valid connection already exists!";
-    error( RtMidiError::WARNING, errorString_ );
-    return;
-  }
-
   CoreMidiData *data = static_cast<CoreMidiData *> (apiData_);
 
   if ( data->endpoint ) {
@@ -994,7 +980,6 @@ void MidiOutCore :: openVirtualPort( std::string portName )
 
   // Save our api-specific connection information.
   data->endpoint = endpoint;
-  connected_ = true;
 }
 
 // Not necessary if we don't treat sysex messages any differently than
@@ -1590,12 +1575,6 @@ void MidiInAlsa :: openPort( unsigned int portNumber, const std::string portName
 
 void MidiInAlsa :: openVirtualPort( std::string portName )
 {
-  if ( connected_ ) {
-    errorString_ = "MidiInAlsa::openVirtualPort: a valid connection already exists!";
-    error( RtMidiError::WARNING, errorString_ );
-    return;
-  }
-
   AlsaMidiData *data = static_cast<AlsaMidiData *> (apiData_);
   if ( data->vport < 0 ) {
     snd_seq_port_info_t *pinfo;
@@ -1654,8 +1633,6 @@ void MidiInAlsa :: openVirtualPort( std::string portName )
       return;
     }
   }
-
-  connected_ = true;
 }
 
 void MidiInAlsa :: closePort( void )
@@ -1854,26 +1831,16 @@ void MidiOutAlsa :: openPort( unsigned int portNumber, const std::string portNam
 
 void MidiOutAlsa :: closePort( void )
 {
-  AlsaMidiData *data = static_cast<AlsaMidiData *> (apiData_);
-
   if ( connected_ ) {
-    if ( data->subscription ) {
-      snd_seq_unsubscribe_port( data->seq, data->subscription );
-      snd_seq_port_subscribe_free( data->subscription );
-      data->subscription = 0;
-    }
+    AlsaMidiData *data = static_cast<AlsaMidiData *> (apiData_);
+    snd_seq_unsubscribe_port( data->seq, data->subscription );
+    snd_seq_port_subscribe_free( data->subscription );
     connected_ = false;
   }
 }
 
 void MidiOutAlsa :: openVirtualPort( std::string portName )
 {
-  if ( connected_ ) {
-    errorString_ = "MidiOutAlsa::openVirtualPort: a valid connection already exists!";
-    error( RtMidiError::WARNING, errorString_ );
-    return;
-  }
-
   AlsaMidiData *data = static_cast<AlsaMidiData *> (apiData_);
   if ( data->vport < 0 ) {
     data->vport = snd_seq_create_simple_port( data->seq, portName.c_str(),
@@ -1883,11 +1850,8 @@ void MidiOutAlsa :: openVirtualPort( std::string portName )
     if ( data->vport < 0 ) {
       errorString_ = "MidiOutAlsa::openVirtualPort: ALSA error creating virtual port.";
       error( RtMidiError::DRIVER_ERROR, errorString_ );
-      return;
     }
   }
-
-  connected_ = true;
 }
 
 void MidiOutAlsa :: sendMessage( std::vector<unsigned char> *message )

--- a/src/lib/RtMidi/RtMidi.cpp
+++ b/src/lib/RtMidi/RtMidi.cpp
@@ -646,6 +646,12 @@ void MidiInCore :: openPort( unsigned int portNumber, const std::string portName
 
 void MidiInCore :: openVirtualPort( const std::string portName )
 {
+  if ( connected_ ) {
+    errorString_ = "MidiInCore::openVirtualPort: a valid connection already exists!";
+    error( RtMidiError::WARNING, errorString_ );
+    return;
+  }
+
   CoreMidiData *data = static_cast<CoreMidiData *> (apiData_);
 
   // Create a virtual MIDI input destination.
@@ -661,6 +667,8 @@ void MidiInCore :: openVirtualPort( const std::string portName )
 
   // Save our api-specific connection information.
   data->endpoint = endpoint;
+
+  connected_ = true;
 }
 
 void MidiInCore :: closePort( void )
@@ -959,6 +967,12 @@ void MidiOutCore :: closePort( void )
 
 void MidiOutCore :: openVirtualPort( std::string portName )
 {
+  if ( connected_ ) {
+    errorString_ = "MidiOutCore::openVirtualPort: a valid connection already exists!";
+    error( RtMidiError::WARNING, errorString_ );
+    return;
+  }
+
   CoreMidiData *data = static_cast<CoreMidiData *> (apiData_);
 
   if ( data->endpoint ) {
@@ -980,6 +994,7 @@ void MidiOutCore :: openVirtualPort( std::string portName )
 
   // Save our api-specific connection information.
   data->endpoint = endpoint;
+  connected_ = true;
 }
 
 // Not necessary if we don't treat sysex messages any differently than
@@ -1575,6 +1590,12 @@ void MidiInAlsa :: openPort( unsigned int portNumber, const std::string portName
 
 void MidiInAlsa :: openVirtualPort( std::string portName )
 {
+  if ( connected_ ) {
+    errorString_ = "MidiInAlsa::openVirtualPort: a valid connection already exists!";
+    error( RtMidiError::WARNING, errorString_ );
+    return;
+  }
+
   AlsaMidiData *data = static_cast<AlsaMidiData *> (apiData_);
   if ( data->vport < 0 ) {
     snd_seq_port_info_t *pinfo;
@@ -1633,6 +1654,8 @@ void MidiInAlsa :: openVirtualPort( std::string portName )
       return;
     }
   }
+
+  connected_ = true;
 }
 
 void MidiInAlsa :: closePort( void )
@@ -1831,16 +1854,26 @@ void MidiOutAlsa :: openPort( unsigned int portNumber, const std::string portNam
 
 void MidiOutAlsa :: closePort( void )
 {
+  AlsaMidiData *data = static_cast<AlsaMidiData *> (apiData_);
+
   if ( connected_ ) {
-    AlsaMidiData *data = static_cast<AlsaMidiData *> (apiData_);
-    snd_seq_unsubscribe_port( data->seq, data->subscription );
-    snd_seq_port_subscribe_free( data->subscription );
+    if ( data->subscription ) {
+      snd_seq_unsubscribe_port( data->seq, data->subscription );
+      snd_seq_port_subscribe_free( data->subscription );
+      data->subscription = 0;
+    }
     connected_ = false;
   }
 }
 
 void MidiOutAlsa :: openVirtualPort( std::string portName )
 {
+  if ( connected_ ) {
+    errorString_ = "MidiOutAlsa::openVirtualPort: a valid connection already exists!";
+    error( RtMidiError::WARNING, errorString_ );
+    return;
+  }
+
   AlsaMidiData *data = static_cast<AlsaMidiData *> (apiData_);
   if ( data->vport < 0 ) {
     data->vport = snd_seq_create_simple_port( data->seq, portName.c_str(),
@@ -1850,8 +1883,11 @@ void MidiOutAlsa :: openVirtualPort( std::string portName )
     if ( data->vport < 0 ) {
       errorString_ = "MidiOutAlsa::openVirtualPort: ALSA error creating virtual port.";
       error( RtMidiError::DRIVER_ERROR, errorString_ );
+      return;
     }
   }
+
+  connected_ = true;
 }
 
 void MidiOutAlsa :: sendMessage( std::vector<unsigned char> *message )

--- a/src/node-midi.cpp
+++ b/src/node-midi.cpp
@@ -31,6 +31,7 @@ public:
         NODE_SET_PROTOTYPE_METHOD(t, "openPort", OpenPort);
         NODE_SET_PROTOTYPE_METHOD(t, "openVirtualPort", OpenVirtualPort);
         NODE_SET_PROTOTYPE_METHOD(t, "closePort", ClosePort);
+        NODE_SET_PROTOTYPE_METHOD(t, "isPortOpen", IsPortOpen);
 
         NODE_SET_PROTOTYPE_METHOD(t, "sendMessage", SendMessage);
 
@@ -120,6 +121,14 @@ public:
         NanReturnUndefined();
     }
 
+    static NAN_METHOD(IsPortOpen)
+    {
+        NanScope();
+        NodeMidiOutput* output = node::ObjectWrap::Unwrap<NodeMidiOutput>(args.This());
+        v8::Local<v8::Boolean> result = NanNew<v8::Boolean>(output->out->isPortOpen());
+        NanReturnValue(result);
+    }
+
     static NAN_METHOD(SendMessage)
     {
         NanScope();
@@ -175,6 +184,7 @@ public:
         NODE_SET_PROTOTYPE_METHOD(t, "openPort", OpenPort);
         NODE_SET_PROTOTYPE_METHOD(t, "openVirtualPort", OpenVirtualPort);
         NODE_SET_PROTOTYPE_METHOD(t, "closePort", ClosePort);
+        NODE_SET_PROTOTYPE_METHOD(t, "isPortOpen", IsPortOpen);
 
         NODE_SET_PROTOTYPE_METHOD(t, "ignoreTypes", IgnoreTypes);
 
@@ -312,6 +322,14 @@ public:
         input->in->closePort();
         uv_close((uv_handle_t*)&input->message_async, NULL);
         NanReturnUndefined();
+    }
+
+    static NAN_METHOD(IsPortOpen)
+    {
+        NanScope();
+        NodeMidiInput* input = node::ObjectWrap::Unwrap<NodeMidiInput>(args.This());
+        v8::Local<v8::Boolean> result = NanNew<v8::Boolean>(input->in->isPortOpen());
+        NanReturnValue(result);
     }
 
     static NAN_METHOD(IgnoreTypes)

--- a/src/node-midi.cpp
+++ b/src/node-midi.cpp
@@ -51,14 +51,13 @@ public:
     static NAN_METHOD(New)
     {
         NanScope();
-
         if (!args.IsConstructCall()) {
-            return NanThrowTypeError("Use the new operator to create instances of this object.");
+            NanThrowTypeError("Use the new operator to create instances of this object.");
+            NanReturnUndefined();
         }
 
         NodeMidiOutput* output = new NodeMidiOutput();
         output->Wrap(args.This());
-
         NanReturnValue(args.This());
     }
 
@@ -75,7 +74,8 @@ public:
         NanScope();
         NodeMidiOutput* output = node::ObjectWrap::Unwrap<NodeMidiOutput>(args.This());
         if (args.Length() == 0 || !args[0]->IsUint32()) {
-            return NanThrowTypeError("First argument must be an integer");
+            NanThrowTypeError("First argument must be an integer");
+            NanReturnUndefined();
         }
 
         unsigned int portNumber = args[0]->Uint32Value();
@@ -89,14 +89,15 @@ public:
         NodeMidiOutput* output = node::ObjectWrap::Unwrap<NodeMidiOutput>(args.This());
         if (output->out->isPortOpen()) {
             NanReturnValue(NanNew<v8::Boolean>(false));
-            return;
         }
         if (args.Length() == 0 || !args[0]->IsUint32()) {
-            return NanThrowTypeError("First argument must be an integer");
+            NanThrowTypeError("First argument must be an integer");
+            NanReturnUndefined();
         }
         unsigned int portNumber = args[0]->Uint32Value();
         if (portNumber >= output->out->getPortCount()) {
-            return NanThrowRangeError("Invalid MIDI port number");
+            NanThrowRangeError("Invalid MIDI port number");
+            NanReturnUndefined();
         }
 
         output->out->openPort(portNumber);
@@ -109,14 +110,13 @@ public:
         NodeMidiOutput* output = node::ObjectWrap::Unwrap<NodeMidiOutput>(args.This());
         if (output->out->isPortOpen()) {
             NanReturnValue(NanNew<v8::Boolean>(false));
-            return;
         }
         if (args.Length() == 0 || !args[0]->IsString()) {
-            return NanThrowTypeError("First argument must be a string");
+            NanThrowTypeError("First argument must be a string");
+            NanReturnUndefined();
         }
 
         std::string name(*NanAsciiString(args[0]));
-
         output->out->openVirtualPort(name);
         NanReturnValue(NanNew<v8::Boolean>(true));
     }
@@ -127,7 +127,6 @@ public:
         NodeMidiOutput* output = node::ObjectWrap::Unwrap<NodeMidiOutput>(args.This());
         if (!output->out->isPortOpen()) {
             NanReturnValue(NanNew<v8::Boolean>(false));
-            return;
         }
 
         output->out->closePort();
@@ -147,7 +146,8 @@ public:
         NanScope();
         NodeMidiOutput* output = node::ObjectWrap::Unwrap<NodeMidiOutput>(args.This());
         if (args.Length() == 0 || !args[0]->IsArray()) {
-            return NanThrowTypeError("First argument must be an array");
+            NanThrowTypeError("First argument must be an array");
+            NanReturnUndefined();
         }
 
         v8::Local<v8::Object> message = args[0]->ToObject();
@@ -257,15 +257,14 @@ public:
     static NAN_METHOD(New)
     {
         NanScope();
-
         if (!args.IsConstructCall()) {
-            return NanThrowTypeError("Use the new operator to create instances of this object.");
+            NanThrowTypeError("Use the new operator to create instances of this object.");
+            NanReturnUndefined();
         }
 
         NodeMidiInput* input = new NodeMidiInput();
         input->message_async.data = input;
         input->Wrap(args.This());
-
         NanReturnValue(args.This());
     }
 
@@ -282,7 +281,8 @@ public:
         NanScope();
         NodeMidiInput* input = node::ObjectWrap::Unwrap<NodeMidiInput>(args.This());
         if (args.Length() == 0 || !args[0]->IsUint32()) {
-            return NanThrowTypeError("First argument must be an integer");
+            NanThrowTypeError("First argument must be an integer");
+            NanReturnUndefined();
         }
 
         unsigned int portNumber = args[0]->Uint32Value();
@@ -296,14 +296,15 @@ public:
         NodeMidiInput* input = node::ObjectWrap::Unwrap<NodeMidiInput>(args.This());
         if (input->in->isPortOpen()) {
             NanReturnValue(NanNew<v8::Boolean>(false));
-            return;
         }
         if (args.Length() == 0 || !args[0]->IsUint32()) {
-            return NanThrowTypeError("First argument must be an integer");
+            NanThrowTypeError("First argument must be an integer");
+            NanReturnUndefined();
         }
         unsigned int portNumber = args[0]->Uint32Value();
         if (portNumber >= input->in->getPortCount()) {
-            return NanThrowRangeError("Invalid MIDI port number");
+            NanThrowRangeError("Invalid MIDI port number");
+            NanReturnUndefined();
         }
 
         input->Ref();
@@ -319,15 +320,14 @@ public:
         NodeMidiInput* input = node::ObjectWrap::Unwrap<NodeMidiInput>(args.This());
         if (input->in->isPortOpen()) {
             NanReturnValue(NanNew<v8::Boolean>(false));
-            return;
         }
         if (args.Length() == 0 || !args[0]->IsString()) {
-            return NanThrowTypeError("First argument must be a string");
+            NanThrowTypeError("First argument must be a string");
+            NanReturnUndefined();
         }
 
-        std::string name(*NanAsciiString(args[0]));
-
         input->Ref();
+        std::string name(*NanAsciiString(args[0]));
         input->in->setCallback(&NodeMidiInput::Callback, input);
         uv_async_init(uv_default_loop(), &input->message_async, NodeMidiInput::EmitMessage);
         input->in->openVirtualPort(name);
@@ -340,7 +340,6 @@ public:
         NodeMidiInput* input = node::ObjectWrap::Unwrap<NodeMidiInput>(args.This());
         if (!input->in->isPortOpen()) {
             NanReturnValue(NanNew<v8::Boolean>(false));
-            return;
         }
 
         input->Unref();
@@ -363,7 +362,8 @@ public:
         NanScope();
         NodeMidiInput* input = node::ObjectWrap::Unwrap<NodeMidiInput>(args.This());
         if (args.Length() != 3 || !args[0]->IsBoolean() || !args[1]->IsBoolean() || !args[2]->IsBoolean()) {
-            return NanThrowTypeError("Arguments must be boolean");
+            NanThrowTypeError("Arguments must be boolean");
+            NanReturnUndefined();
         }
 
         bool filter_sysex = args[0]->BooleanValue();

--- a/src/node-midi.cpp
+++ b/src/node-midi.cpp
@@ -261,7 +261,6 @@ public:
 
         NodeMidiInput* input = new NodeMidiInput();
         input->message_async.data = input;
-        uv_async_init(uv_default_loop(), &input->message_async, NodeMidiInput::EmitMessage);
         input->Wrap(args.This());
 
         NanReturnValue(args.This());
@@ -305,6 +304,7 @@ public:
 
         input->Ref();
         input->in->setCallback(&NodeMidiInput::Callback, node::ObjectWrap::Unwrap<NodeMidiInput>(args.This()));
+        uv_async_init(uv_default_loop(), &input->message_async, NodeMidiInput::EmitMessage);
         input->in->openPort(portNumber);
         NanReturnUndefined();
     }
@@ -324,6 +324,7 @@ public:
 
         input->Ref();
         input->in->setCallback(&NodeMidiInput::Callback, node::ObjectWrap::Unwrap<NodeMidiInput>(args.This()));
+        uv_async_init(uv_default_loop(), &input->message_async, NodeMidiInput::EmitMessage);
         input->in->openVirtualPort(name);
         NanReturnUndefined();
     }

--- a/src/node-midi.cpp
+++ b/src/node-midi.cpp
@@ -87,6 +87,9 @@ public:
     {
         NanScope();
         NodeMidiOutput* output = node::ObjectWrap::Unwrap<NodeMidiOutput>(args.This());
+        if (output->out->isPortOpen()) {
+            return NanThrowError("Port already open");
+        }
         if (args.Length() == 0 || !args[0]->IsUint32()) {
             return NanThrowTypeError("First argument must be an integer");
         }
@@ -103,6 +106,9 @@ public:
     {
         NanScope();
         NodeMidiOutput* output = node::ObjectWrap::Unwrap<NodeMidiOutput>(args.This());
+        if (output->out->isPortOpen()) {
+            return NanThrowError("Port already open");
+        }
         if (args.Length() == 0 || !args[0]->IsString()) {
             return NanThrowTypeError("First argument must be a string");
         }
@@ -117,6 +123,10 @@ public:
     {
         NanScope();
         NodeMidiOutput* output = node::ObjectWrap::Unwrap<NodeMidiOutput>(args.This());
+        if (!output->out->isPortOpen()) {
+            return NanThrowError("Port already closed");
+        }
+
         output->out->closePort();
         NanReturnUndefined();
     }
@@ -282,6 +292,9 @@ public:
     {
         NanScope();
         NodeMidiInput* input = node::ObjectWrap::Unwrap<NodeMidiInput>(args.This());
+        if (input->in->isPortOpen()) {
+            return NanThrowError("Port already open");
+        }
         if (args.Length() == 0 || !args[0]->IsUint32()) {
             return NanThrowTypeError("First argument must be an integer");
         }
@@ -300,6 +313,9 @@ public:
     {
         NanScope();
         NodeMidiInput* input = node::ObjectWrap::Unwrap<NodeMidiInput>(args.This());
+        if (input->in->isPortOpen()) {
+            return NanThrowError("Port already open");
+        }
         if (args.Length() == 0 || !args[0]->IsString()) {
             return NanThrowTypeError("First argument must be a string");
         }
@@ -316,9 +332,11 @@ public:
     {
         NanScope();
         NodeMidiInput* input = node::ObjectWrap::Unwrap<NodeMidiInput>(args.This());
-        if (input->in->isPortOpen()) {
-            input->Unref();
+        if (!input->in->isPortOpen()) {
+            return NanThrowError("Port already closed");
         }
+
+        input->Unref();
         input->in->closePort();
         uv_close((uv_handle_t*)&input->message_async, NULL);
         NanReturnUndefined();

--- a/src/node-midi.cpp
+++ b/src/node-midi.cpp
@@ -88,7 +88,8 @@ public:
         NanScope();
         NodeMidiOutput* output = node::ObjectWrap::Unwrap<NodeMidiOutput>(args.This());
         if (output->out->isPortOpen()) {
-            return NanThrowError("Port already open");
+            NanReturnValue(NanNew<v8::Boolean>(false));
+            return;
         }
         if (args.Length() == 0 || !args[0]->IsUint32()) {
             return NanThrowTypeError("First argument must be an integer");
@@ -99,7 +100,7 @@ public:
         }
 
         output->out->openPort(portNumber);
-        NanReturnUndefined();
+        NanReturnValue(NanNew<v8::Boolean>(true));
     }
 
     static NAN_METHOD(OpenVirtualPort)
@@ -107,7 +108,8 @@ public:
         NanScope();
         NodeMidiOutput* output = node::ObjectWrap::Unwrap<NodeMidiOutput>(args.This());
         if (output->out->isPortOpen()) {
-            return NanThrowError("Port already open");
+            NanReturnValue(NanNew<v8::Boolean>(false));
+            return;
         }
         if (args.Length() == 0 || !args[0]->IsString()) {
             return NanThrowTypeError("First argument must be a string");
@@ -116,7 +118,7 @@ public:
         std::string name(*NanAsciiString(args[0]));
 
         output->out->openVirtualPort(name);
-        NanReturnUndefined();
+        NanReturnValue(NanNew<v8::Boolean>(true));
     }
 
     static NAN_METHOD(ClosePort)
@@ -124,11 +126,12 @@ public:
         NanScope();
         NodeMidiOutput* output = node::ObjectWrap::Unwrap<NodeMidiOutput>(args.This());
         if (!output->out->isPortOpen()) {
-            return NanThrowError("Port already closed");
+            NanReturnValue(NanNew<v8::Boolean>(false));
+            return;
         }
 
         output->out->closePort();
-        NanReturnUndefined();
+        NanReturnValue(NanNew<v8::Boolean>(true));
     }
 
     static NAN_METHOD(IsPortOpen)
@@ -292,7 +295,8 @@ public:
         NanScope();
         NodeMidiInput* input = node::ObjectWrap::Unwrap<NodeMidiInput>(args.This());
         if (input->in->isPortOpen()) {
-            return NanThrowError("Port already open");
+            NanReturnValue(NanNew<v8::Boolean>(false));
+            return;
         }
         if (args.Length() == 0 || !args[0]->IsUint32()) {
             return NanThrowTypeError("First argument must be an integer");
@@ -306,7 +310,7 @@ public:
         input->in->setCallback(&NodeMidiInput::Callback, input);
         uv_async_init(uv_default_loop(), &input->message_async, NodeMidiInput::EmitMessage);
         input->in->openPort(portNumber);
-        NanReturnUndefined();
+        NanReturnValue(NanNew<v8::Boolean>(true));
     }
 
     static NAN_METHOD(OpenVirtualPort)
@@ -314,7 +318,8 @@ public:
         NanScope();
         NodeMidiInput* input = node::ObjectWrap::Unwrap<NodeMidiInput>(args.This());
         if (input->in->isPortOpen()) {
-            return NanThrowError("Port already open");
+            NanReturnValue(NanNew<v8::Boolean>(false));
+            return;
         }
         if (args.Length() == 0 || !args[0]->IsString()) {
             return NanThrowTypeError("First argument must be a string");
@@ -326,7 +331,7 @@ public:
         input->in->setCallback(&NodeMidiInput::Callback, input);
         uv_async_init(uv_default_loop(), &input->message_async, NodeMidiInput::EmitMessage);
         input->in->openVirtualPort(name);
-        NanReturnUndefined();
+        NanReturnValue(NanNew<v8::Boolean>(true));
     }
 
     static NAN_METHOD(ClosePort)
@@ -334,14 +339,15 @@ public:
         NanScope();
         NodeMidiInput* input = node::ObjectWrap::Unwrap<NodeMidiInput>(args.This());
         if (!input->in->isPortOpen()) {
-            return NanThrowError("Port already closed");
+            NanReturnValue(NanNew<v8::Boolean>(false));
+            return;
         }
 
         input->Unref();
         input->in->closePort();
         input->in->cancelCallback();
         uv_close((uv_handle_t*)&input->message_async, NULL);
-        NanReturnUndefined();
+        NanReturnValue(NanNew<v8::Boolean>(true));
     }
 
     static NAN_METHOD(IsPortOpen)

--- a/src/node-midi.cpp
+++ b/src/node-midi.cpp
@@ -303,7 +303,7 @@ public:
         }
 
         input->Ref();
-        input->in->setCallback(&NodeMidiInput::Callback, node::ObjectWrap::Unwrap<NodeMidiInput>(args.This()));
+        input->in->setCallback(&NodeMidiInput::Callback, input);
         uv_async_init(uv_default_loop(), &input->message_async, NodeMidiInput::EmitMessage);
         input->in->openPort(portNumber);
         NanReturnUndefined();
@@ -323,7 +323,7 @@ public:
         std::string name(*NanAsciiString(args[0]));
 
         input->Ref();
-        input->in->setCallback(&NodeMidiInput::Callback, node::ObjectWrap::Unwrap<NodeMidiInput>(args.This()));
+        input->in->setCallback(&NodeMidiInput::Callback, input);
         uv_async_init(uv_default_loop(), &input->message_async, NodeMidiInput::EmitMessage);
         input->in->openVirtualPort(name);
         NanReturnUndefined();
@@ -339,6 +339,7 @@ public:
 
         input->Unref();
         input->in->closePort();
+        input->in->cancelCallback();
         uv_close((uv_handle_t*)&input->message_async, NULL);
         NanReturnUndefined();
     }

--- a/test/unit-tests.js
+++ b/test/unit-tests.js
@@ -62,6 +62,14 @@ describe('midi.input', function() {
         input.openPort(999);
       }).should.throw('Invalid MIDI port number');
     });
+
+    it('should return true if not already open', function() {
+      input.openPort(0).should.be.Boolean.and.eql(true);
+    });
+
+    it('should return false if already open', function() {
+      input.openPort(0).should.be.Boolean.and.eql(false);
+    });
   });
 
   describe('.openVirtualPort', function() {
@@ -78,6 +86,14 @@ describe('midi.input', function() {
         input.openVirtualPort(999);
       }).should.throw('First argument must be a string');
     });
+
+    it('should return true if not already open', function() {
+      input.openVirtualPort("test").should.be.Boolean.and.eql(true);
+    });
+
+    it('should return false if already open', function() {
+      input.openVirtualPort("test").should.be.Boolean.and.eql(false);
+    });
   });
 
   describe('.closePort', function() {
@@ -85,6 +101,48 @@ describe('midi.input', function() {
 
     it('allows you to close a port that was not opened', function() {
       input.closePort();
+    });
+
+    it('should return true if not already closed for openPort()', function() {
+      input.openPort(0);
+      input.closePort().should.be.Boolean.and.eql(true);
+    });
+
+    it('should return false if already closed for openPort()', function() {
+      input.closePort().should.be.Boolean.and.eql(false);
+    });
+
+    it('should return true if not already closed for openVirtualPort()', function() {
+      input.openVirtualPort("test");
+      input.closePort().should.be.Boolean.and.eql(true);
+    });
+
+    it('should return false if already closed for openVirtualPort()', function() {
+      input.closePort().should.be.Boolean.and.eql(false);
+    });
+  });
+
+  describe('.isPortOpen', function() {
+    var input = new Midi.input();
+
+    it('should return true if port open for openPort()', function() {
+      input.openPort(0);
+      input.isPortOpen().should.be.a.Boolean.and.eql(true);
+    });
+
+    it('should return false if port closed for openPort()', function() {
+      input.closePort();
+      input.isPortOpen().should.be.a.Boolean.and.eql(false);
+    });
+
+    it('should return true if port open for openVirtualPort()', function() {
+      input.openVirtualPort("test");
+      input.isPortOpen().should.be.a.Boolean.and.eql(true);
+    });
+
+    it('should return false if port closed for openVirtualPort()', function() {
+      input.closePort();
+      input.isPortOpen().should.be.a.Boolean.and.eql(false);
     });
   });
 });
@@ -149,6 +207,14 @@ describe('midi.output', function() {
         output.openPort(999);
       }).should.throw('Invalid MIDI port number');
     });
+
+    it('should return true if not already open', function() {
+      output.openPort(0).should.be.Boolean.and.eql(true);
+    });
+
+    it('should return false if already open', function() {
+      output.openPort(0).should.be.Boolean.and.eql(false);
+    });
   });
 
   describe('.openVirtualPort', function() {
@@ -165,6 +231,14 @@ describe('midi.output', function() {
         output.openVirtualPort(999);
       }).should.throw('First argument must be a string');
     });
+
+    it('should return true if not already open', function() {
+      output.openVirtualPort("test").should.be.Boolean.and.eql(true);
+    });
+
+    it('should return false if already open', function() {
+      output.openVirtualPort("test").should.be.Boolean.and.eql(false);
+    });
   });
 
   describe('.closePort', function() {
@@ -172,6 +246,48 @@ describe('midi.output', function() {
 
     it('allows you to close a port that was not opened', function() {
       output.closePort();
+    });
+
+    it('should return true if not already closed for openPort()', function() {
+      output.openPort(0);
+      output.closePort().should.be.Boolean.and.eql(true);
+    });
+
+    it('should return false if already closed for openPort()', function() {
+      output.closePort().should.be.Boolean.and.eql(false);
+    });
+
+    it('should return true if not already closed for openVirtualPort()', function() {
+      output.openVirtualPort("test");
+      output.closePort().should.be.Boolean.and.eql(true);
+    });
+
+    it('should return false if already closed for openVirtualPort()', function() {
+      output.closePort().should.be.Boolean.and.eql(false);
+    });
+  });
+
+  describe('.isPortOpen', function() {
+    var output = new Midi.output();
+
+    it('should return true if port open for openPort()', function() {
+      output.openPort(0);
+      output.isPortOpen().should.be.a.Boolean.and.eql(true);
+    });
+
+    it('should return false if port closed for openPort()', function() {
+      output.closePort();
+      output.isPortOpen().should.be.a.Boolean.and.eql(false);
+    });
+
+    it('should return true if port open for openVirtualPort()', function() {
+      output.openVirtualPort("test");
+      output.isPortOpen().should.be.a.Boolean.and.eql(true);
+    });
+
+    it('should return false if port closed for openVirtualPort()', function() {
+      output.closePort();
+      output.isPortOpen().should.be.a.Boolean.and.eql(false);
     });
   });
 });


### PR DESCRIPTION
Hi !
I improved some things of this great node package. In particular I made the following changes:
- Added a new `isPortOpen()` method for the MIDI input and output objects. This method returns `true` or false depending if the port is opened or not.
- Added a little bit more advanced logic for ports opening/closing. In particular `openPort()` and `closePort()` will throw an error if the port was already opened or closed.
- Moved the call to the `uv_async_init()` method from the `New()` method to the `openPort()` and `openVirtualPort()` methods. This makes the initialization of the event emitting thread to be delayed until you actually open the MIDI input port. Why? because if you don't do this the Node program will hang before exiting until you call the `closePort()`, method no matter if you opened the port at some point. An example of when you don't need to open the port is when scanning for available port names.
- Made the `closePort()` method of the MIDI input object to unregister the callback function from the underlying RtMidi input object. This makes no real effect on everyday usage of the API, but takes away a bug if you try to re-open any MIDI port using the same MIDI input object. There is still and underlying bug in RtMidi that makes re-using MIDI input objects impossible, however I'm trying to see how to fix it. This problem only affects MIDI input, not MIDI output objects. This probably because of the callback mechanism.

Cheers and hoping soon for a 0.9.3 version =).
