### PR TITLE
Added short description of message format.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ From source:
 
 ### Input
 
+The received `message` is an array of numbers corresponding to the midi bytes: `[status, data1, data2]`. Detailed information on the MIDI format can be found [on this page](https://www.cs.cf.ac.uk/Dave/Multimedia/node158.html) for example.
+
 ```js
 var midi = require('midi');
 


### PR DESCRIPTION
The received 'message' object could be anything and it can help users having simple pointers in the documentation. In fact, the 'message' parameter could be renamed to 'bytes' for clarity...