### PR TITLE
Call cancelCallback when closing port

### DIFF
--- a/src/node-midi.cpp
+++ b/src/node-midi.cpp
@@ -309,6 +309,7 @@ public:
         if (input->in->isPortOpen()) {
             input->Unref();
         }
+        input->in->cancelCallback();
         input->in->closePort();
         uv_close((uv_handle_t*)&input->message_async, NULL);
         NanReturnUndefined();

--- a/test/input-reopen-test.js
+++ b/test/input-reopen-test.js
@@ -1,0 +1,28 @@
+var midi = require('../midi.js');
+var input;
+
+var newInput = function(port) {
+  if (input) {
+    input.closePort();
+  }
+
+  console.log('new input', port);
+
+  input = new midi.input();
+
+  input.on('message', function(deltaTime, message) {
+    console.log('m:' + message + ' d:' + deltaTime);
+  });
+
+  input.openPort(port);
+};
+
+newInput(0);
+
+setTimeout(function() {
+  newInput(0);
+}, 5000);
+
+setTimeout(function() {
+  input.closePort();
+}, 10000);


### PR DESCRIPTION
Fixes problems with reopening ports with `midi.input()`.