### PR TITLE
Fix Travis: io.js 3.x requires g++ 4.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,22 @@ node_js:
   - "0.10"
   - "0.8"
   - "iojs"
-  - "iojs-v1.0.4"
-before_install:
- - sudo apt-get install libasound2-dev alsa-utils alsa-oss
+  - "iojs-v2"
+  - "iojs-v1"
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - g++-4.8
+    - libasound2-dev
 notifications:
   email: false
 # Travis has no snd-dummy driver (https://github.com/travis-ci/travis-ci/issues/1754)
-# so our tests won't run. We run `npm install` as the test script so build errors
-# appear as test failures.
+# preventing our tests from running. Instead we disable the default `npm install`
+# installation step and run it as test script so compilation erros will mark the
+# build as failed.
 install: true
-script: npm install
+script:
+  - export CXX=g++-4.8
+  - npm install


### PR DESCRIPTION
Inspired by https://github.com/nodejs/nan/commit/05ed3b67d9e755592f696b4a41542657a90ab4b2

Also made some other changes to clean things up:
- Removed unused dependencies
- Now using the container based builds which are twice as fast
- Testing against io.js versions 1, 2 and 3 now
