### PR TITLE
Trying to fix the build for node 0.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: node_js
 node_js:
+  - "4.0"
   - "0.12"
   - "0.10"
   - "0.8"
   - "iojs"
   - "iojs-v2"
   - "iojs-v1"
+sudo: false
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,17 @@ notifications:
   email: false
 # Travis has no snd-dummy driver (https://github.com/travis-ci/travis-ci/issues/1754)
 # preventing our tests from running. Instead we disable the default `npm install`
-# installation step and run it as test script so compilation erros will mark the
+# installation step and run it as test script so compilation errors will mark the
 # build as failed.
-install: true
+install:
+  - case ${TRAVIS_NODE_VERSION} in
+        iojs*)
+            echo "Not upgrading npm for iojs."
+            ;;
+        *)
+            npm update -g npm
+            ;;
+    esac
 script:
   - export CXX=g++-4.8
   - npm install


### PR DESCRIPTION
For 0.8 the build is failing due to one of mocha's dependencies using the ^ version matching syntax:
```
No compatible version found: clean-css@'^3.1.9'
```
It seems like we'd need to update npm to work around that but my first attempt breaks the iojs builds.