### PR TITLE
fix virtual ports close

### DIFF
--- a/src/lib/RtMidi/RtMidi.cpp
+++ b/src/lib/RtMidi/RtMidi.cpp
@@ -950,11 +950,17 @@ void MidiOutCore :: openPort( unsigned int portNumber, const std::string portNam
 
 void MidiOutCore :: closePort( void )
 {
-  if ( connected_ ) {
-    CoreMidiData *data = static_cast<CoreMidiData *> (apiData_);
-    MIDIPortDispose( data->port );
-    connected_ = false;
+  CoreMidiData *data = static_cast<CoreMidiData *> (apiData_);
+
+  if ( data->endpoint ) {
+    MIDIEndpointDispose( data->endpoint );
   }
+
+  if ( data->port ) {
+    MIDIPortDispose( data->port );
+  }
+
+  connected_ = false;
 }
 
 void MidiOutCore :: openVirtualPort( std::string portName )

--- a/src/lib/RtMidi/RtMidi.cpp
+++ b/src/lib/RtMidi/RtMidi.cpp
@@ -665,11 +665,17 @@ void MidiInCore :: openVirtualPort( const std::string portName )
 
 void MidiInCore :: closePort( void )
 {
-  if ( connected_ ) {
-    CoreMidiData *data = static_cast<CoreMidiData *> (apiData_);
-    MIDIPortDispose( data->port );
-    connected_ = false;
+  CoreMidiData *data = static_cast<CoreMidiData *> (apiData_);
+
+  if ( data->endpoint ) {
+    MIDIEndpointDispose( data->endpoint );
   }
+
+  if ( data->port ) {
+    MIDIPortDispose( data->port );
+  }
+
+  connected_ = false;
 }
 
 unsigned int MidiInCore :: getPortCount()

--- a/test/virtual-input-close-test.js
+++ b/test/virtual-input-close-test.js
@@ -1,0 +1,21 @@
+var midi = require('../midi.js');
+var input;
+
+[ 'a', 'b', 'c', 'd' ].forEach(function(portName) {
+  if (input) {
+    input.closePort();
+  }
+
+  input = new midi.input();
+  input.openVirtualPort(portName);
+});
+
+var output = new midi.output();
+
+console.log('ports: ' + output.getPortCount());
+
+for (var i = 0; i < output.getPortCount(); ++i) {
+  console.log('port [' + i + ']: ' + output.getPortName(i));
+}
+
+input.closePort();

--- a/test/virtual-output-close-test.js
+++ b/test/virtual-output-close-test.js
@@ -1,0 +1,19 @@
+var midi = require('../midi.js');
+var output;
+
+[ 'a', 'b', 'c', 'd' ].forEach(function(portName) {
+  if (output) {
+    output.closePort();
+  }
+
+  output = new midi.output();
+  output.openVirtualPort(portName);
+});
+
+var input = new midi.input();
+
+console.log('ports: ' + input.getPortCount());
+
+for (var i = 0; i < input.getPortCount(); ++i) {
+  console.log('port [' + i + ']: ' + input.getPortName(i));
+}

--- a/test/virtual-output-close-test.js
+++ b/test/virtual-output-close-test.js
@@ -17,3 +17,5 @@ console.log('ports: ' + input.getPortCount());
 for (var i = 0; i < input.getPortCount(); ++i) {
   console.log('port [' + i + ']: ' + input.getPortName(i));
 }
+
+output.closePort();


### PR DESCRIPTION
Turns out not only virtual output keeps "hanging around" in OSX, there's a problem with virtual input as well.

Reference issue: https://github.com/justinlatimer/node-midi/issues/75
