### PR TITLE
Enabled isPortOpen for both Input and Output ports

### DIFF
--- a/src/node-midi.cpp
+++ b/src/node-midi.cpp
@@ -28,6 +28,8 @@ public:
         Nan::SetPrototypeMethod(t, "openVirtualPort", OpenVirtualPort);
         Nan::SetPrototypeMethod(t, "closePort", ClosePort);
 
+        Nan::SetPrototypeMethod(t, "isPortOpen", IsPortOpen);
+
         Nan::SetPrototypeMethod(t, "sendMessage", SendMessage);
 
         target->Set(Nan::New<v8::String>("output").ToLocalChecked(), t->GetFunction());
@@ -116,6 +118,14 @@ public:
         return;
     }
 
+    static NAN_METHOD(IsPortOpen)
+    {
+        Nan::HandleScope scope;
+        NodeMidiOutput* output = Nan::ObjectWrap::Unwrap<NodeMidiOutput>(info.This());
+        v8::Local<v8::Boolean> result = Nan::New<v8::Boolean>(output->out->isPortOpen());
+        info.GetReturnValue().Set(result);
+    }
+
     static NAN_METHOD(SendMessage)
     {
         Nan::HandleScope scope;
@@ -171,6 +181,8 @@ public:
         Nan::SetPrototypeMethod(t, "openPort", OpenPort);
         Nan::SetPrototypeMethod(t, "openVirtualPort", OpenVirtualPort);
         Nan::SetPrototypeMethod(t, "closePort", ClosePort);
+
+        Nan::SetPrototypeMethod(t, "isPortOpen", IsPortOpen);
 
         Nan::SetPrototypeMethod(t, "ignoreTypes", IgnoreTypes);
 
@@ -309,6 +321,14 @@ public:
         input->in->closePort();
         uv_close((uv_handle_t*)&input->message_async, NULL);
         return;
+    }
+
+    static NAN_METHOD(IsPortOpen)
+    {
+        Nan::HandleScope scope;
+        NodeMidiInput* input = Nan::ObjectWrap::Unwrap<NodeMidiInput>(info.This());
+        v8::Local<v8::Boolean> result = Nan::New<v8::Boolean>(input->in->isPortOpen());
+        info.GetReturnValue().Set(result);
     }
 
     static NAN_METHOD(IgnoreTypes)

--- a/test/isInPortOpen-test.js
+++ b/test/isInPortOpen-test.js
@@ -1,0 +1,9 @@
+var midi = require("../midi.js");
+
+var input = new midi.input();
+
+console.log('Is open ', input.isPortOpen());
+input.openPort(0);
+console.log('Is open ', input.isPortOpen());
+
+input.closePort();

--- a/test/isOutPortOpen-test.js
+++ b/test/isOutPortOpen-test.js
@@ -1,0 +1,9 @@
+var midi = require("../midi.js");
+
+var output = new midi.output();
+
+console.log('Is open ', output.isPortOpen());
+output.openPort(0);
+console.log('Is open ', output.isPortOpen());
+
+output.closePort();


### PR DESCRIPTION
I am not at all good with c++, but I needed this extra check for my current project.

2 tests are added to show that it returns false until the port is open.
