### PR TITLE
Updating NAN to the latest version. This allows node 6.2.0 to be used.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - "6.2"
   - "5.1"
   - "4.2"
   - "0.12"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "bindings": "~1.2.1",
-    "nan": "~2.0.5"
+    "nan": "^2.3.3"
   },
   "devDependencies": {
     "mocha": ">= 2.1.0",


### PR DESCRIPTION
Fixes issue #106 