### PR TITLE
Upgrade nan module version to fix node 6.X build issue.

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "bindings": "~1.2.1",
-    "nan": "^2.3.3"
+    "nan": "^2.3.5"
   },
   "devDependencies": {
     "mocha": ">= 2.1.0",


### PR DESCRIPTION
When I install this module on node 6.X environment, I got the following error.

```
  CXX(target) Release/obj.target/nslog/src/main.o
In file included from ../src/main.cc:3:
../../nan/nan.h:590:20: error: no type named 'GCEpilogueCallback' in 'v8::Isolate'
      v8::Isolate::GCEpilogueCallback callback
      ~~~~~~~~~~~~~^
../../nan/nan.h:596:20: error: no type named 'GCEpilogueCallback' in 'v8::Isolate'
      v8::Isolate::GCEpilogueCallback callback) {
      ~~~~~~~~~~~~~^
../../nan/nan.h:601:20: error: no type named 'GCPrologueCallback' in 'v8::Isolate'
      v8::Isolate::GCPrologueCallback callback
      ~~~~~~~~~~~~~^
../../nan/nan.h:607:20: error: no type named 'GCPrologueCallback' in 'v8::Isolate'
      v8::Isolate::GCPrologueCallback callback) {
      ~~~~~~~~~~~~~^
4 errors generated.
make: *** [Release/obj.target/nslog/src/main.o] Error 1
gyp ERR! build error
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/Users/poly/.nvm/versions/node/v6.2.2/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:276:23)
gyp ERR! stack     at emitTwo (events.js:106:13)
gyp ERR! stack     at ChildProcess.emit (events.js:191:7)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:204:12)
gyp ERR! System Darwin 15.5.0
gyp ERR! command "/Users/poly/.nvm/versions/node/v6.2.2/bin/node" "/Users/poly/.nvm/versions/node/v6.2.2/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /Users/poly/ws/animatronics/nativeapp/node_modules/nslog
gyp ERR! node -v v6.2.2
gyp ERR! node-gyp -v v3.3.1
gyp ERR! not ok
```

It happens because `node-midi` depends on the old version of `nan` which uses deprecated type. This PR fixed the issue by upgrading `nan` module to 2.3.5 in which the node 6.X issue is fixed.