### PR TITLE
Fixing read stream resume bug

### DIFF
--- a/midi.js
+++ b/midi.js
@@ -31,7 +31,7 @@ midi.createReadStream = function(input) {
 
   stream.resume = function() {
     stream.paused = false;
-    while (stream.queue.length && stream.write(queue.shift())) {}
+    while (stream.queue.length && stream.emit('data', stream.queue.shift())) {}
   };
 
   return stream;

--- a/test/virtual-readStream-test.js
+++ b/test/virtual-readStream-test.js
@@ -20,10 +20,12 @@ for (var i = 0; i < output.getPortCount(); ++i) {
     break;
   }
 }
-
+reader.pause()
 output.sendMessage(payload);
+
+setTimeout(function() { reader.resume(); }, 10)
 
 setTimeout(function() {
   assert(called);
   process.exit(0);
-}, 10);
+}, 100);


### PR DESCRIPTION
Without this fix, `midi.createReadStream()` cannot be `resume`d. 

I updated the `createReadStream` test to simulate the error.
