### PR TITLE
Prevent Output client from disappearing and add Jack-Midi support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ addons:
     packages:
     - g++-4.8
     - libasound2-dev
+    - libjack-jackd2-dev
 notifications:
   email: false
 # Travis has no snd-dummy driver (https://github.com/travis-ci/travis-ci/issues/1754)

--- a/binding.gyp
+++ b/binding.gyp
@@ -16,12 +16,14 @@
               '-fno-exceptions'
             ],
             'defines': [
-              '__LINUX_ALSA__'
+              '__LINUX_ALSA__',
+              '__UNIX_JACK__'
             ],
             'link_settings': {
               'libraries': [
                 '-lasound',
                 '-lpthread',
+                '-ljack'
               ]
             }
           }

--- a/src/node-midi.cpp
+++ b/src/node-midi.cpp
@@ -57,7 +57,7 @@ public:
         if (info.Length() >= 1 && !info[0]->IsString()) {
             return Nan::ThrowTypeError("First argument must be a boolean");
         } else if (info[0]->IsString()) {
-            name = (*v8::String::Utf8Value(info[0].As<v8::String>()));
+            name = *v8::String::Utf8Value(info[0].As<v8::String>());
         }
 
         if (info.Length() == 2 && !info[1]->IsBoolean()) {
@@ -261,7 +261,7 @@ public:
         if (info.Length() >= 1 && !info[0]->IsString()) {
             return Nan::ThrowTypeError("First argument must be a boolean");
         } else if (info[0]->IsString()) {
-            name = (*v8::String::Utf8Value(info[0].As<v8::String>()));
+            name = *v8::String::Utf8Value(info[0].As<v8::String>());
         }
 
         if (info.Length() == 2 && !info[1]->IsBoolean()) {

--- a/src/node-midi.cpp
+++ b/src/node-midi.cpp
@@ -90,6 +90,7 @@ public:
             return Nan::ThrowRangeError("Invalid MIDI port number");
         }
 
+        output->Ref();
         output->out->openPort(portNumber);
         return;
     }
@@ -104,6 +105,7 @@ public:
 
         std::string name(*v8::String::Utf8Value(info[0].As<v8::String>()));
 
+        output->Ref();
         output->out->openVirtualPort(name);
         return;
     }
@@ -112,6 +114,9 @@ public:
     {
         Nan::HandleScope scope;
         NodeMidiOutput* output = Nan::ObjectWrap::Unwrap<NodeMidiOutput>(info.This());
+        if (output->out->isPortOpen()) {
+            output->Unref();
+        }
         output->out->closePort();
         return;
     }

--- a/src/node-midi.cpp
+++ b/src/node-midi.cpp
@@ -33,9 +33,9 @@ public:
         target->Set(Nan::New<v8::String>("output").ToLocalChecked(), t->GetFunction());
     }
 
-    NodeMidiOutput()
+    NodeMidiOutput(RtMidi::Api api, std::string name)
     {
-        out = new RtMidiOut();
+        out = new RtMidiOut(api, name);
     }
 
     ~NodeMidiOutput()
@@ -51,7 +51,22 @@ public:
             return Nan::ThrowTypeError("Use the new operator to create instances of this object.");
         }
 
-        NodeMidiOutput* output = new NodeMidiOutput();
+        std::string name = std::string("nodeMidi Output");
+        RtMidi::Api api = RtMidi::Api::UNSPECIFIED;
+
+        if (info.Length() >= 1 && !info[0]->IsString()) {
+            return Nan::ThrowTypeError("First argument must be a boolean");
+        } else if (info[0]->IsString()) {
+            name = (*v8::String::Utf8Value(info[0].As<v8::String>()));
+        }
+
+        if (info.Length() == 2 && !info[1]->IsBoolean()) {
+            return Nan::ThrowTypeError("Second argument must be a boolean");
+        } else if (info[1]->IsTrue()) {
+            api = RtMidi::Api::UNIX_JACK;
+        }
+
+        NodeMidiOutput* output = new NodeMidiOutput(api, name);
         output->Wrap(info.This());
 
         info.GetReturnValue().Set(info.This());
@@ -182,9 +197,9 @@ public:
         target->Set(Nan::New<v8::String>("input").ToLocalChecked(), t->GetFunction());
     }
 
-    NodeMidiInput()
+    NodeMidiInput(RtMidi::Api api, std::string name)
     {
-        in = new RtMidiIn();
+        in = new RtMidiIn(api, name);
         uv_mutex_init(&message_mutex);
     }
 
@@ -240,7 +255,22 @@ public:
             return Nan::ThrowTypeError("Use the new operator to create instances of this object.");
         }
 
-        NodeMidiInput* input = new NodeMidiInput();
+        std::string name = std::string("nodeMidi Input");
+        RtMidi::Api api = RtMidi::Api::UNSPECIFIED;
+
+        if (info.Length() >= 1 && !info[0]->IsString()) {
+            return Nan::ThrowTypeError("First argument must be a boolean");
+        } else if (info[0]->IsString()) {
+            name = (*v8::String::Utf8Value(info[0].As<v8::String>()));
+        }
+
+        if (info.Length() == 2 && !info[1]->IsBoolean()) {
+            return Nan::ThrowTypeError("Second argument must be a boolean");
+        } else if (info[1]->IsTrue()) {
+            api = RtMidi::Api::UNIX_JACK;
+        }
+
+        NodeMidiInput* input = new NodeMidiInput(api, name);
         input->message_async.data = input;
         uv_async_init(uv_default_loop(), &input->message_async, NodeMidiInput::EmitMessage);
         input->Wrap(info.This());

--- a/src/node-midi.cpp
+++ b/src/node-midi.cpp
@@ -52,7 +52,7 @@ public:
         }
 
         std::string name = std::string("nodeMidi Output");
-        RtMidi::Api api = RtMidi::Api::UNSPECIFIED;
+        RtMidi::Api api = RtMidi::UNSPECIFIED;
 
         if (info.Length() >= 1 && !info[0]->IsString()) {
             return Nan::ThrowTypeError("First argument must be a boolean");
@@ -63,7 +63,7 @@ public:
         if (info.Length() == 2 && !info[1]->IsBoolean()) {
             return Nan::ThrowTypeError("Second argument must be a boolean");
         } else if (info[1]->IsTrue()) {
-            api = RtMidi::Api::UNIX_JACK;
+            api = RtMidi::UNIX_JACK;
         }
 
         NodeMidiOutput* output = new NodeMidiOutput(api, name);
@@ -256,7 +256,7 @@ public:
         }
 
         std::string name = std::string("nodeMidi Input");
-        RtMidi::Api api = RtMidi::Api::UNSPECIFIED;
+        RtMidi::Api api = RtMidi::UNSPECIFIED;
 
         if (info.Length() >= 1 && !info[0]->IsString()) {
             return Nan::ThrowTypeError("First argument must be a boolean");
@@ -267,7 +267,7 @@ public:
         if (info.Length() == 2 && !info[1]->IsBoolean()) {
             return Nan::ThrowTypeError("Second argument must be a boolean");
         } else if (info[1]->IsTrue()) {
-            api = RtMidi::Api::UNIX_JACK;
+            api = RtMidi::UNIX_JACK;
         }
 
         NodeMidiInput* input = new NodeMidiInput(api, name);


### PR DESCRIPTION
This pull request brings the following changes:

- enable jack support for linux at compilation time (requires `libjack-jackd2-dev`)
- prevent output midi clients from disappearing[1] (call `output->Ref();` when opening a new port) 
- add 2 optional parameters to `midi.input` and `midi.output` constructors:
  - `string`: client name
  - `bool`: use jack backend
- set default client name to `nodeMidi Input / Output` instead of `RtMidi Input / Output`

[1] on linux, using jack and alsa backend
