### PR TITLE
Defer uv handle initialization until openPort called.

### DIFF
--- a/test/input/input-hang-test.js
+++ b/test/input/input-hang-test.js
@@ -1,0 +1,2 @@
+var midi = require("../../midi.js");
+var input = new midi.input();

--- a/test/input/input-reopen-test.js
+++ b/test/input/input-reopen-test.js
@@ -1,20 +1,18 @@
 var midi = require('../../midi.js');
-var input;
+var input = new midi.input();
+input.on('message', function(deltaTime, message) {
+  console.log('m:' + message + ' d:' + deltaTime);
+});
 
 var newInput = function(port) {
   if (input) {
     input.closePort();
   }
 
-  console.log('new input', port);
-
-  input = new midi.input();
-
-  input.on('message', function(deltaTime, message) {
-    console.log('m:' + message + ' d:' + deltaTime);
-  });
-
-  input.openPort(port);
+  setTimeout(function() {
+    console.log('new input', port);
+    input.openPort(port);
+  }, 100);
 };
 
 newInput(0);


### PR DESCRIPTION
* Refactor when the `uv_async_t` handle is initialized, not needed until a port is opened.
* Refactor how the handle is cleaned up.

Should fix:  #112, #117 
Hat tip: @geeksunny https://github.com/geeksunny/node-midi/commit/227843342d8e65d7a1695ccf1a60a7b6e988f50f