### PR TITLE
Ensure promises can be resolved inside on('message') callbacks

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -87,7 +87,8 @@ NAUV_WORK_CB(NodeMidiInput::EmitMessage)
             Nan::Set(data, Nan::New<v8::Number>(i), Nan::New<v8::Integer>(message->message[i]));
         }
         info[2] = data;
-        Nan::Call(emitFunction, input->handle(), 3, info);
+        Nan::Callback callback_emit(emitFunction);
+        callback_emit.Call(input->handle(), 3, info);
         input->message_queue.pop();
         delete message;
     }

--- a/test/unit/input.js
+++ b/test/unit/input.js
@@ -84,4 +84,72 @@ describe('midi.Input', function() {
     });
   });
 
+
+  describe(".on('message')", function() {
+    it('allows promises to resolve', async function() {
+      const portName = 'node-midi Virtual Loopback';
+
+      // Create a promise we can use to pass/fail the whole test.
+      let resolveTestPromise, rejectTestPromise;
+      const testPromise = new Promise((resolve, reject) => {
+        resolveTestPromise = resolve;
+        rejectTestPromise = reject;
+      });
+
+      // Create a promise to resolve in the on('message') callback.
+      let resolvePendingPromise, rejectPendingPromise;
+      const promise = new Promise((resolve, reject) => {
+        resolvePendingPromise = resolve;
+        rejectPendingPromise = reject;
+      });
+
+      // Create a virtual loopback MIDI port.
+      var input = new Midi.Input();
+      input.on('message', function(deltaTime, message) {
+        // Resolve the promise now we have received a MIDI message.
+        resolvePendingPromise(message);
+      });
+      input.openVirtualPort(portName);
+
+      let awaitComplete = false;
+      setTimeout(function() {
+        input.closePort();
+        if (!awaitComplete) {
+          // If the `await` statement below has not yet returned, then this is
+          // a failure.
+          rejectTestPromise(new Error('Await did not return in time'));
+        }
+      }, 1500); // Must be under 2000 or Mocha fails us for being too slow.
+
+      // Find the other end of the virtual MIDI port we created above.
+      const output = new Midi.Output();
+      for (var i = 0; i < output.getPortCount(); ++i) {
+        if (output.getPortName(i).includes(portName)) {
+          output.openPort(i);
+        }
+      }
+      if (!output.isPortOpen()) {
+        throw Error('Unable to find virtual loopback port');
+      }
+
+      // Send a message, which should end up calling the on('message') handler.
+      output.sendMessage([176, 22, 1]);
+      output.closePort();
+
+      // Wait for the promise resolved by on('message').  If everything is
+      // working, this promise has already been resolved and will complete
+      // immediately.  However if the event loop is starved, it will block
+      // until the next event arrives, resulting in a timeout.
+      const result = await promise;
+      awaitComplete = true;
+
+      // Resolve the promise for this test, which will have no effect if the
+      // promise has already been rejected because the `await` took too long.
+      resolveTestPromise();
+
+      // Wait for the test promise, which will cause an exception to be thrown
+      // if the test promise was rejected.
+      await testPromise;
+    });
+  });
 });


### PR DESCRIPTION
This fixes #157 and includes test code.

I'm not sure whether this is the ideal fix so feel free to suggest alternatives, but it does fix the problem and doesn't break any of the other tests.