### PR TITLE
Increase buffer size

### DIFF
--- a/src/lib/RtMidi/RtMidi.cpp
+++ b/src/lib/RtMidi/RtMidi.cpp
@@ -2386,7 +2386,7 @@ static std::string ConvertToUTF8(const TCHAR *str)
   return u8str;
 }
 
-#define  RT_SYSEX_BUFFER_SIZE 1024
+#define  RT_SYSEX_BUFFER_SIZE 2048
 #define  RT_SYSEX_BUFFER_COUNT 4
 
 // A structure to hold variables related to the CoreMIDI API


### PR DESCRIPTION
@justinlatimer As promised via Email, here's a simple change that doubles the buffer size for sysex messages - We had to change this to make the module work with a couple of Novation/Focusrite devices that use bigger sysex messages as means to speed up transfer.

This should be fine in most contexts, initially we just wondered if this maybe should be something user configurable. 