### PR TITLE
Make MIDI port names consistent on Windows.

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -60,7 +60,8 @@
             },
             'defines': [
               '__WINDOWS_MM__',
-              'RT_SYSEX_BUFFER_SIZE=2048'
+              'RT_SYSEX_BUFFER_SIZE=2048',
+              'RTMIDI_DO_NOT_ENSURE_UNIQUE_PORTNAMES'
             ],
             'link_settings': {
               'libraries': [

--- a/test/input/input-list-test.js
+++ b/test/input/input-list-test.js
@@ -1,0 +1,8 @@
+var midi = require("../../midi.js");
+
+var input = new midi.Input();
+console.log('Input ports: ' + input.getPortCount());
+
+for (var i = 0; i < input.getPortCount(); ++i) {
+    console.log('Port ' + i + ' name: ' + input.getPortName(i));
+}

--- a/test/output/output-list-test.js
+++ b/test/output/output-list-test.js
@@ -1,0 +1,8 @@
+var midi = require("../../midi.js");
+
+var output = new midi.Output();
+console.log('Output ports: ' + output.getPortCount());
+
+for (var i = 0; i < output.getPortCount(); ++i) {
+    console.log('Port ' + i + ' name: ' + output.getPortName(i));
+}


### PR DESCRIPTION
RtMidi by default — [on Windows](https://github.com/thestk/rtmidi/blob/master/RtMidi.cpp#L72) — appends a number to the name of the MIDI port to ensure the names are unique. This behavior is probably unexpected, so disable it with a #define in the project.

Fixes #160—@lozjackson.