### PR TITLE
Make native module context-aware

### DIFF
--- a/src/midi.cpp
+++ b/src/midi.cpp
@@ -11,4 +11,4 @@ NAN_MODULE_INIT(InitAll) {
     NodeMidiInput::Init(target);
 }
 
-NODE_MODULE(midi, InitAll)
+NAN_MODULE_WORKER_ENABLED(midi, InitAll)


### PR DESCRIPTION
Electron 14.0+ requires the module to be context-aware to be importable.

Fixes #164
References: electron/electron#18397